### PR TITLE
In order to mirror facebook tutorial, use marked-rails for markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ end
 
 gem 'react-rails', github: 'reactjs/react-rails', branch: 'master'
 
-gem 'showdown-rails'
+gem 'marked-rails'
 
 gem 'bootstrap-sass'
 gem 'autoprefixer-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.1)
       mime-types (>= 1.16, < 3)
+    marked-rails (0.3.2.0)
     mime-types (2.3)
     mini_portile (0.6.0)
     minitest (5.4.0)
@@ -136,9 +137,6 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    showdown-rails (0.0.4)
-      actionpack (>= 3.1)
-      railties (>= 3.1)
     spring (1.1.3)
     sprockets (2.12.1)
       hike (~> 1.2)
@@ -176,6 +174,7 @@ DEPENDENCIES
   coffee-rails (~> 4.0.0)
   jbuilder (~> 2.0)
   jquery-rails
+  marked-rails
   pg
   rails (= 4.2.0.beta1)
   rails-html-sanitizer (~> 1.0)
@@ -183,7 +182,6 @@ DEPENDENCIES
   react-rails!
   sass-rails (~> 5.0.0.beta1)
   sdoc (~> 0.4.0)
-  showdown-rails
   spring
   sqlite3
   turbolinks

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,6 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require bootstrap-sprockets
-//= require showdown
+//= require marked
 //= require react
 //= require_tree .

--- a/app/assets/javascripts/comments.js.jsx
+++ b/app/assets/javascripts/comments.js.jsx
@@ -1,10 +1,8 @@
 /** @jsx React.DOM */
 
-var converter = new Showdown.converter();
-
 var Comment = React.createClass({
   render: function() {
-    var rawMarkup = converter.makeHtml(this.props.children.toString());
+    var rawMarkup = marked(this.props.children.toString(), {sanitize: true});
     return (
       <div className="comment panel panel-default">
         <div className="panel-heading">


### PR DESCRIPTION
The facebook tutorial switched from showdown to marked: https://github.com/reactjs/react-tutorial/commit/233dbf72df45d3b713fda0b8bf28c94c504defa5
